### PR TITLE
feat: improve renderer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/lib.rs"
 [dependencies]
 crossterm = "0.21.0"
 crossbeam-channel = "0.5.1"
+parking_lot = "0.11.1"
 
 [workspace]
 members = [

--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -47,10 +47,10 @@ impl Program for App {
     fn view(&self) -> String {
         format!(
             "count: {}\n\
-            [r]: reset\n\
-            [↑]: increment\n\
-            [↓]: decrement\n\
-            [q]: quit\n",
+            [r] reset\n\
+            [↑] increment\n\
+            [↓] decrement\n\
+            [q] quit\n",
             self.count
         )
     }

--- a/examples/timer/src/main.rs
+++ b/examples/timer/src/main.rs
@@ -59,8 +59,8 @@ impl Program for App {
     fn view(&self) -> String {
         format!(
             "count: {}\n\
-            [r]: reset\n\
-            [q]: quit\n",
+            [r] reset\n\
+            [q] quit\n",
             self.count
         )
     }

--- a/src/program.rs
+++ b/src/program.rs
@@ -56,7 +56,7 @@ pub trait Program: Sized {
         // spin up key/mouse event listener
         let event_listener = {
             let tx = tx.clone();
-            WorkerThread::new(move |done| loop {
+            WorkerThread::spawn(move |done| loop {
                 if event::poll(Duration::from_millis(100)).unwrap() {
                     tx.send(Event::Term(event::read().unwrap())).unwrap();
                 }
@@ -78,7 +78,7 @@ pub trait Program: Sized {
 
         loop {
             // update the view
-            config.renderer.render(self.view()).unwrap();
+            config.renderer.render(self.view());
 
             // handle the event/message
             match rx.recv().unwrap() {

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -1,21 +1,43 @@
-use crossterm::cursor::MoveUp;
-use crossterm::queue;
+use crossbeam_channel::{select, tick};
+use crossterm::cursor::{self, MoveUp};
 use crossterm::style::Print;
 use crossterm::terminal;
 use crossterm::terminal::{Clear, ClearType};
+use crossterm::{execute, queue};
+use parking_lot::Mutex;
 use std::io::{self, Write as _};
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::worker_thread::WorkerThread;
 
 enum Output {
     Stdout(Screen),
-    Buffered(String),
+    Buffered(WriteBuffer),
 }
 
+const DEFAULT_FRAMERATE: usize = 60;
+const DEFAULT_BUF_CAPACITY: usize = 1_024;
+
+/// A screen represents a terminal for displaying output, a write buffer
+/// for storing UI updates until they're ready to be flushed, and a worker
+/// thread responsible for watching the write buffer and flushing it on
+/// a regular interval.
 struct Screen {
+    buffer: Arc<Mutex<WriteBuffer>>,
     handle: io::Stdout,
-    lines_rendered: u32,
-    last_render: Option<String>,
+    worker: Option<WorkerThread>,
 }
 
+/// A write buffer is a light wrapper around a `String` that tracks
+/// whether it's been written to, allowing readers to skip work if
+/// no changes have been written since the previous read.
+struct WriteBuffer {
+    dirty: bool,
+    inner: String,
+}
+
+/// A renderer is responsible for displaying a program's view.
 pub struct Renderer {
     output: Output,
 }
@@ -23,69 +45,147 @@ pub struct Renderer {
 impl Screen {
     fn new() -> Self {
         Self {
+            buffer: Arc::new(Mutex::new(WriteBuffer::new())),
             handle: io::stdout(),
-            lines_rendered: 0,
-            last_render: None,
+            worker: None,
         }
     }
 }
 
+impl WriteBuffer {
+    fn new() -> Self {
+        Self {
+            dirty: false,
+            inner: String::with_capacity(DEFAULT_BUF_CAPACITY),
+        }
+    }
+
+    fn output(&self) -> String {
+        self.inner.clone()
+    }
+
+    fn write(&mut self, string: &str) {
+        self.inner.replace_range(.., string);
+        self.dirty = true;
+    }
+}
+
 impl Renderer {
+    /// Render output to stdout (the default).
     pub fn stdout() -> Self {
         Self {
             output: Output::Stdout(Screen::new()),
         }
     }
 
+    /// Render output to a string buffer (don't display anything on screen).
+    ///
+    /// This should generally only be used for testing.
     pub fn buffered() -> Self {
         Self {
-            output: Output::Buffered(String::new()),
+            output: Output::Buffered(WriteBuffer::new()),
         }
     }
 
-    pub fn output(&self) -> &str {
-        if let Output::Buffered(ref buf) = self.output {
-            buf
-        } else {
-            panic!("can only retrieve output when buffered")
-        }
-    }
-
-    pub(crate) fn init(&self) {
+    /// Retrieve a copy of the renderer's most recent output.
+    ///
+    /// This should generally only be used for testing.
+    pub fn output(&self) -> String {
         match self.output {
-            Output::Stdout(_) => terminal::enable_raw_mode().unwrap(),
+            Output::Buffered(ref buf) => buf.output(),
+            Output::Stdout(ref screen) => screen.buffer.lock().output(),
+        }
+    }
+
+    pub(crate) fn init(&mut self) {
+        match self.output {
+            Output::Stdout(ref mut screen) => {
+                // enter raw mode and hide cursor
+                terminal::enable_raw_mode().unwrap();
+                execute!(screen.handle, cursor::Hide).unwrap();
+
+                // start up worker thread to handle drawing to screen
+                screen.worker = Some(spawn_render_thread(&screen.buffer));
+            }
             Output::Buffered(_) => {}
         }
     }
 
-    pub(crate) fn close(&self) {
+    pub(crate) fn close(&mut self) {
         match self.output {
-            Output::Stdout(_) => terminal::disable_raw_mode().unwrap(),
+            Output::Stdout(ref mut screen) => {
+                // close worker thread
+                screen.worker.take().unwrap().close();
+
+                // disable raw mode and re-enable cursor
+                terminal::disable_raw_mode().unwrap();
+                execute!(screen.handle, cursor::Show).unwrap();
+            }
             Output::Buffered(_) => {}
         }
     }
 
-    pub(crate) fn render(&mut self, view: String) -> io::Result<()> {
+    pub(crate) fn render(&mut self, view: String) {
         match self.output {
-            Output::Stdout(ref mut screen) => render_to_stdout(screen, view),
-            Output::Buffered(ref mut buf) => render_buffered(buf, view),
+            Output::Stdout(ref mut screen) => screen.buffer.lock().write(view.as_ref()),
+            Output::Buffered(ref mut buf) => buf.write(view.as_ref()),
         }
     }
 }
 
-// TODO: intelligent diffing (don't queue unnecessary commands)
-fn render_to_stdout(screen: &mut Screen, view: String) -> io::Result<()> {
-    let stdout = &mut screen.handle;
-    let old_lines: Vec<&str> = screen
-        .last_render
+fn spawn_render_thread(buffer: &Arc<Mutex<WriteBuffer>>) -> WorkerThread {
+    let buffer = Arc::clone(buffer);
+    WorkerThread::spawn(move |done| {
+        let mut stdout = io::stdout();
+        let mut last_render: Option<String> = None;
+        let frame_delay = (1_000. / DEFAULT_FRAMERATE as f64).floor() as u64;
+        let next_frame = tick(Duration::from_millis(frame_delay));
+
+        loop {
+            select! {
+                recv(next_frame) -> _ => {
+                    let mut buffer = buffer.lock();
+                    if buffer.dirty {
+                        render_to_stdout(&mut stdout, &mut last_render, buffer.inner.as_ref()).unwrap();
+                        buffer.dirty = false;
+                    }
+                }
+                recv(done) -> _ => {
+                    break;
+                }
+            }
+        }
+    })
+}
+
+fn render_to_stdout(
+    stdout: &mut io::Stdout,
+    last_render: &mut Option<String>,
+    view: &str,
+) -> io::Result<()> {
+    // if nothing's changed, do nothing
+    if last_render.as_deref() == Some(view) {
+        return Ok(());
+    }
+
+    let old_lines: Vec<&str> = last_render
         .as_ref()
         .map(|s| s.split("\n").collect())
         .unwrap_or_else(Vec::new);
     let new_lines: Vec<&str> = view.split("\n").collect();
 
     // clear lines from previous render (if any)
-    for (i, _line) in old_lines.iter().rev().enumerate() {
-        queue!(stdout, Clear(ClearType::CurrentLine))?;
+    for (i, line) in old_lines.iter().enumerate().rev() {
+        if new_lines.len() <= old_lines.len()
+            && (new_lines.len() > i && old_lines.len() > i)
+            && new_lines[i] == *line
+        {
+            // The number of lines we're rendering hasn't increased and
+            // this new line is the same as the old line, so do nothing.
+        } else {
+            queue!(stdout, Clear(ClearType::CurrentLine))?;
+        }
+
         if i > 0 {
             queue!(stdout, MoveUp(1))?;
         }
@@ -99,12 +199,7 @@ fn render_to_stdout(screen: &mut Screen, view: String) -> io::Result<()> {
         }
     }
 
-    screen.lines_rendered = new_lines.len() as _;
-    screen.last_render = Some(view);
+    // flush to the screen
+    *last_render = Some(view.to_owned());
     stdout.flush()
-}
-
-fn render_buffered(buf: &mut String, view: String) -> io::Result<()> {
-    buf.replace_range(.., view.as_ref());
-    Ok(())
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -33,7 +33,7 @@ impl<T: Clone + Send + 'static> Timer<T> {
 
         let interval = self.interval;
         let message = self.message.clone();
-        let worker = WorkerThread::new(move |done| {
+        let worker = WorkerThread::spawn(move |done| {
             let ticker = tick(interval);
 
             loop {

--- a/src/worker_thread.rs
+++ b/src/worker_thread.rs
@@ -10,7 +10,7 @@ pub struct WorkerThread {
 
 impl WorkerThread {
     /// Spawn a worker closure in a new thread.
-    pub fn new<F>(fun: F) -> Self
+    pub fn spawn<F>(fun: F) -> Self
     where
         F: FnOnce(Receiver<()>) + Send + 'static,
     {


### PR DESCRIPTION
The renderer now performs line-by-line diffing (if a line hasn't changed since the previous render, it's not updated), and also writes updates to an internal buffer that's flushed 60 times per second, instead of always flushing updates directly to the screen.

This also fixes a bug where the topmost line of text wouldn't be properly cleared between renders.

Closes #1.